### PR TITLE
enable compression by default for WebApps on Linux

### DIFF
--- a/8.5-jre8/server.xml
+++ b/8.5-jre8/server.xml
@@ -71,7 +71,11 @@
     <Connector port="${port.http}" protocol="HTTP/1.1"
                connectionTimeout="20000"
                redirectPort="8443"
-               maxHttpHeaderSize="16384" />
+               maxHttpHeaderSize="16384"
+             compression="on"
+             compressionMinSize="1024"
+             noCompressionUserAgents="gozilla, traviata"
+             compressableMimeType="text/html,text/xml" />
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"


### PR DESCRIPTION
enable compression by default for WebApps on Linux that run Java with Tomcat 9