### PR TITLE
Change tmp directory name to avoid name collision

### DIFF
--- a/8.5-jre8/Dockerfile
+++ b/8.5-jre8/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=appsvc/java:8-jre8_0000000000
 FROM $BASE_IMAGE
-MAINTAINER Azure App Services Container Images <appsvc-images@microsoft.com>
+LABEL mainteinter="Azure App Services Container Images <appsvc-images@microsoft.com>"
 
 ENV AI_VERSION 2.1.2
 ENV TOMCAT_VERSION 8.5.33
@@ -18,12 +18,16 @@ ENV _JAVA_OPTIONS -Djava.net.preferIPv4Stack=true
 
 ENV PATH /usr/local/tomcat/bin:$PATH
 
+# Remove the sample webapps provided by Tomcat
 RUN rm -rf /usr/local/tomcat/webapps/
 
+# Remove the artifacts created by the base Java image, as we know we don't need them
+RUN rm -rf /tmp/webapps/
+
 COPY init_container.sh /bin/init_container.sh
-COPY web.xml /tmp/tomcat/web.xml
-COPY index.jsp /tmp/webapps/ROOT/index.jsp
-COPY background.png /tmp/webapps/ROOT/background.png
+COPY web.xml /tmp/tomcat/conf/web.xml
+COPY index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
+COPY background.png /tmp/tomcat/webapps/ROOT/background.png
 COPY sshd_config /etc/ssh/
 COPY tmp/shared/app_insights/AI-Agent.xml /usr/local/app_insights/aiagent/
 COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tomcat_lib/

--- a/8.5-jre8/init_container.sh
+++ b/8.5-jre8/init_container.sh
@@ -40,7 +40,7 @@ fi
 if [ ! -d /home/site/wwwroot/webapps ]
 then
     mkdir -p /home/site/wwwroot
-    cp -r /tmp/webapps /home/site/wwwroot
+    cp -r /tmp/tomcat/webapps /home/site/wwwroot
 fi
 
 # Temporary workaround until wardeploy supports clean deployment.
@@ -73,7 +73,7 @@ then
     echo "Initializing App Insights.."
     export CATALINA_OPTS=-javaagent:/usr/local/app_insights/aiagent/applicationinsights-agent-$AI_VERSION.jar $CATALINA_OPTS
     mv /usr/local/app_insights/tomcat_lib/* /usr/local/tomcat/lib/
-    mv /tmp/tomcat/web.xml /usr/local/tomcat/conf/web.xml
+    mv /tmp/tomcat/conf/web.xml /usr/local/tomcat/conf/web.xml
 else
     echo "Skipping App Insights initialization"
 fi

--- a/9.0-jre8/Dockerfile
+++ b/9.0-jre8/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=appsvc/java:8-jre8_0000000000
 FROM $BASE_IMAGE
-MAINTAINER Azure App Services Container Images <appsvc-images@microsoft.com>
+LABEL mainteinter="Azure App Services Container Images <appsvc-images@microsoft.com>"
 
 ENV AI_VERSION 2.1.2
 ENV TOMCAT_VERSION 9.0.11
@@ -18,12 +18,16 @@ ENV _JAVA_OPTIONS -Djava.net.preferIPv4Stack=true
 
 ENV PATH /usr/local/tomcat/bin:$PATH
 
+# Remove the sample webapps provided by Tomcat
 RUN rm -rf /usr/local/tomcat/webapps/
 
+# Remove the artifacts created by the base Java image, as we know we don't need them
+RUN rm -rf /tmp/webapps/
+
 COPY init_container.sh /bin/init_container.sh
-COPY web.xml /tmp/tomcat/web.xml
-COPY index.jsp /tmp/webapps/ROOT/index.jsp
-COPY background.png /tmp/webapps/ROOT/background.png
+COPY web.xml /tmp/tomcat/conf/web.xml
+COPY index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
+COPY background.png /tmp/tomcat/webapps/ROOT/background.png
 COPY sshd_config /etc/ssh/
 COPY tmp/shared/app_insights/AI-Agent.xml /usr/local/app_insights/aiagent/
 COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tomcat_lib/

--- a/9.0-jre8/init_container.sh
+++ b/9.0-jre8/init_container.sh
@@ -40,7 +40,7 @@ fi
 if [ ! -d /home/site/wwwroot/webapps ]
 then
     mkdir -p /home/site/wwwroot
-    cp -r /tmp/webapps /home/site/wwwroot
+    cp -r /tmp/tomcat/webapps /home/site/wwwroot
 fi
 
 # Temporary workaround until wardeploy supports clean deployment.
@@ -73,7 +73,7 @@ then
     echo "Initializing App Insights.."
     export CATALINA_OPTS=-javaagent:/usr/local/app_insights/aiagent/applicationinsights-agent-$AI_VERSION.jar $CATALINA_OPTS
     mv /usr/local/app_insights/tomcat_lib/* /usr/local/tomcat/lib/
-    mv /tmp/tomcat/web.xml /usr/local/tomcat/conf/web.xml
+    mv /tmp/tomcat/conf/web.xml /usr/local/tomcat/conf/web.xml
 else
     echo "Skipping App Insights initialization"
 fi


### PR DESCRIPTION
- Tomcat as well as the base Java image, both, use the /tmp/webapps directory to store temporary artifacts (example: default.jar). As a result, the Tomcat image ends up containing artifacts from the Java image, which we do not want.
- Fix for this is to avoid the name collision by using a separate directory /tmp/tomcat that does not conflict with the /tmp/webapps directory used by Java. This doesn't guarantee that we won't run into conflicts like these in the future, but is a reasonable approach in the short term.
- Also, removing the /tmp/webapps directory as the Tomcat image does not need it.
- MAINTAINER is deprecated. Updated Dockerfile to use LABEL instead.