### PR TITLE
Propagate all environment variables to other sessions (ssh, etc)

### DIFF
--- a/8.5-java11/init_container.sh
+++ b/8.5-java11/init_container.sh
@@ -85,71 +85,11 @@ export _JAVA_OPTIONS="$_JAVA_OPTIONS -Djava.net.preferIPv4Stack=true"
 
 # END: Define JAVA OPTIONS
 
-# BEGIN: Configure ~/.profile
+# BEGIN: Configure /etc/profile
 
-# After all env vars are defined, add the ones of interest to ~/.profile
-# Adding to ~/.profile makes the env vars available to new login sessions (ssh) of the same user.
+eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/g' | sed '/=/s//="/' | sed 's/$/"/' >> /etc/profile)
 
-# list of variables that will be added to ~/.profile
-export_vars=()
-
-# Step 1. Add app settings to ~/.profile
-# To check if an environment variable xyz is an app setting, we check if APPSETTING_xyz is defined as an env var
-while read -r var
-do
-    if [ -n "`printenv APPSETTING_$var`" ]
-    then
-        export_vars+=($var)
-    fi
-done <<< `printenv | cut -d "=" -f 1 | grep -v ^APPSETTING_`
-
-# Step 2. Add well known environment variables to ~/.profile
-well_known_env_vars=( 
-    CATALINA_HOME
-    CATALINA_BASE
-    CATALINA_OPTS
-    HTTP_LOGGING_ENABLED
-    WEBSITE_SITE_NAME
-    WEBSITE_ROLE_INSTANCE_ID
-    TOMCAT_VERSION
-    JAVA_OPTS
-    JAVA_HOME
-    JAVA_VERSION
-    TOMCAT_MAJOR
-    WEBSITE_INSTANCE_ID
-    _JAVA_OPTIONS
-    TOMCAT_SHA1
-    JAVA_ALPINE_VERSION
-    JAVA_DEBIAN_VERSION
-    AI_VERSION
-    )
-
-for var in "${well_known_env_vars[@]}"
-do
-    if [ -n "`printenv $var`" ]
-    then
-        export_vars+=($var)
-    fi
-done
-
-# Step 3. Add environment variables with well known prefixes to ~/.profile
-while read -r var
-do
-    export_vars+=($var)
-done <<< `printenv | cut -d "=" -f 1 | grep -E "^(WEBSITE|APPSETTING|SQLCONNSTR|MYSQLCONNSTR|SQLAZURECONNSTR|CUSTOMCONNSTR)_"`
-
-# Write the variables to be exported to ~/.profile
-for export_var in "${export_vars[@]}"
-do
-    echo Exporting env var $export_var
-    # We use single quotes to preserve escape characters
-	echo export $export_var=\'`printenv $export_var`\' >> ~/.profile
-done
-
-# We want all ssh sesions to start in the /home directory
-echo "cd /home" >> ~/.profile
-
-# END: Configure ~/.profile
+# END: Configure /etc/profile
 
 # BEGIN: Process startup file / startup command, if any
 

--- a/8.5-jre8/init_container.sh
+++ b/8.5-jre8/init_container.sh
@@ -85,71 +85,11 @@ export _JAVA_OPTIONS="$_JAVA_OPTIONS -Djava.net.preferIPv4Stack=true"
 
 # END: Define JAVA OPTIONS
 
-# BEGIN: Configure ~/.profile
+# BEGIN: Configure /etc/profile
 
-# After all env vars are defined, add the ones of interest to ~/.profile
-# Adding to ~/.profile makes the env vars available to new login sessions (ssh) of the same user.
+eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/g' | sed '/=/s//="/' | sed 's/$/"/' >> /etc/profile)
 
-# list of variables that will be added to ~/.profile
-export_vars=()
-
-# Step 1. Add app settings to ~/.profile
-# To check if an environment variable xyz is an app setting, we check if APPSETTING_xyz is defined as an env var
-while read -r var
-do
-    if [ -n "`printenv APPSETTING_$var`" ]
-    then
-        export_vars+=($var)
-    fi
-done <<< `printenv | cut -d "=" -f 1 | grep -v ^APPSETTING_`
-
-# Step 2. Add well known environment variables to ~/.profile
-well_known_env_vars=( 
-    CATALINA_HOME
-    CATALINA_BASE
-    CATALINA_OPTS
-    HTTP_LOGGING_ENABLED
-    WEBSITE_SITE_NAME
-    WEBSITE_ROLE_INSTANCE_ID
-    TOMCAT_VERSION
-    JAVA_OPTS
-    JAVA_HOME
-    JAVA_VERSION
-    TOMCAT_MAJOR
-    WEBSITE_INSTANCE_ID
-    _JAVA_OPTIONS
-    TOMCAT_SHA1
-    JAVA_ALPINE_VERSION
-    JAVA_DEBIAN_VERSION
-    AI_VERSION
-    )
-
-for var in "${well_known_env_vars[@]}"
-do
-    if [ -n "`printenv $var`" ]
-    then
-        export_vars+=($var)
-    fi
-done
-
-# Step 3. Add environment variables with well known prefixes to ~/.profile
-while read -r var
-do
-    export_vars+=($var)
-done <<< `printenv | cut -d "=" -f 1 | grep -E "^(WEBSITE|APPSETTING|SQLCONNSTR|MYSQLCONNSTR|SQLAZURECONNSTR|CUSTOMCONNSTR)_"`
-
-# Write the variables to be exported to ~/.profile
-for export_var in "${export_vars[@]}"
-do
-    echo Exporting env var $export_var
-    # We use single quotes to preserve escape characters
-	echo export $export_var=\'`printenv $export_var`\' >> ~/.profile
-done
-
-# We want all ssh sesions to start in the /home directory
-echo "cd /home" >> ~/.profile
-
-# END: Configure ~/.profile
+# END: Configure /etc/profile
 
 # BEGIN: Process startup file / startup command, if any
 

--- a/9.0-java11/init_container.sh
+++ b/9.0-java11/init_container.sh
@@ -85,71 +85,11 @@ export _JAVA_OPTIONS="$_JAVA_OPTIONS -Djava.net.preferIPv4Stack=true"
 
 # END: Define JAVA OPTIONS
 
-# BEGIN: Configure ~/.profile
+# BEGIN: Configure /etc/profile
 
-# After all env vars are defined, add the ones of interest to ~/.profile
-# Adding to ~/.profile makes the env vars available to new login sessions (ssh) of the same user.
+eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/g' | sed '/=/s//="/' | sed 's/$/"/' >> /etc/profile)
 
-# list of variables that will be added to ~/.profile
-export_vars=()
-
-# Step 1. Add app settings to ~/.profile
-# To check if an environment variable xyz is an app setting, we check if APPSETTING_xyz is defined as an env var
-while read -r var
-do
-    if [ -n "`printenv APPSETTING_$var`" ]
-    then
-        export_vars+=($var)
-    fi
-done <<< `printenv | cut -d "=" -f 1 | grep -v ^APPSETTING_`
-
-# Step 2. Add well known environment variables to ~/.profile
-well_known_env_vars=( 
-    CATALINA_HOME
-    CATALINA_BASE
-    CATALINA_OPTS
-    HTTP_LOGGING_ENABLED
-    WEBSITE_SITE_NAME
-    WEBSITE_ROLE_INSTANCE_ID
-    TOMCAT_VERSION
-    JAVA_OPTS
-    JAVA_HOME
-    JAVA_VERSION
-    TOMCAT_MAJOR
-    WEBSITE_INSTANCE_ID
-    _JAVA_OPTIONS
-    TOMCAT_SHA1
-    JAVA_ALPINE_VERSION
-    JAVA_DEBIAN_VERSION
-    AI_VERSION
-    )
-
-for var in "${well_known_env_vars[@]}"
-do
-    if [ -n "`printenv $var`" ]
-    then
-        export_vars+=($var)
-    fi
-done
-
-# Step 3. Add environment variables with well known prefixes to ~/.profile
-while read -r var
-do
-    export_vars+=($var)
-done <<< `printenv | cut -d "=" -f 1 | grep -E "^(WEBSITE|APPSETTING|SQLCONNSTR|MYSQLCONNSTR|SQLAZURECONNSTR|CUSTOMCONNSTR)_"`
-
-# Write the variables to be exported to ~/.profile
-for export_var in "${export_vars[@]}"
-do
-    echo Exporting env var $export_var
-    # We use single quotes to preserve escape characters
-	echo export $export_var=\'`printenv $export_var`\' >> ~/.profile
-done
-
-# We want all ssh sesions to start in the /home directory
-echo "cd /home" >> ~/.profile
-
-# END: Configure ~/.profile
+# END: Configure /etc/profile
 
 # BEGIN: Process startup file / startup command, if any
 

--- a/9.0-jre8/init_container.sh
+++ b/9.0-jre8/init_container.sh
@@ -85,71 +85,11 @@ export _JAVA_OPTIONS="$_JAVA_OPTIONS -Djava.net.preferIPv4Stack=true"
 
 # END: Define JAVA OPTIONS
 
-# BEGIN: Configure ~/.profile
+# BEGIN: Configure /etc/profile
 
-# After all env vars are defined, add the ones of interest to ~/.profile
-# Adding to ~/.profile makes the env vars available to new login sessions (ssh) of the same user.
+eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/g' | sed '/=/s//="/' | sed 's/$/"/' >> /etc/profile)
 
-# list of variables that will be added to ~/.profile
-export_vars=()
-
-# Step 1. Add app settings to ~/.profile
-# To check if an environment variable xyz is an app setting, we check if APPSETTING_xyz is defined as an env var
-while read -r var
-do
-    if [ -n "`printenv APPSETTING_$var`" ]
-    then
-        export_vars+=($var)
-    fi
-done <<< `printenv | cut -d "=" -f 1 | grep -v ^APPSETTING_`
-
-# Step 2. Add well known environment variables to ~/.profile
-well_known_env_vars=( 
-    CATALINA_HOME
-    CATALINA_BASE
-    CATALINA_OPTS
-    HTTP_LOGGING_ENABLED
-    WEBSITE_SITE_NAME
-    WEBSITE_ROLE_INSTANCE_ID
-    TOMCAT_VERSION
-    JAVA_OPTS
-    JAVA_HOME
-    JAVA_VERSION
-    TOMCAT_MAJOR
-    WEBSITE_INSTANCE_ID
-    _JAVA_OPTIONS
-    TOMCAT_SHA1
-    JAVA_ALPINE_VERSION
-    JAVA_DEBIAN_VERSION
-    AI_VERSION
-    )
-
-for var in "${well_known_env_vars[@]}"
-do
-    if [ -n "`printenv $var`" ]
-    then
-        export_vars+=($var)
-    fi
-done
-
-# Step 3. Add environment variables with well known prefixes to ~/.profile
-while read -r var
-do
-    export_vars+=($var)
-done <<< `printenv | cut -d "=" -f 1 | grep -E "^(WEBSITE|APPSETTING|SQLCONNSTR|MYSQLCONNSTR|SQLAZURECONNSTR|CUSTOMCONNSTR)_"`
-
-# Write the variables to be exported to ~/.profile
-for export_var in "${export_vars[@]}"
-do
-    echo Exporting env var $export_var
-    # We use single quotes to preserve escape characters
-	echo export $export_var=\'`printenv $export_var`\' >> ~/.profile
-done
-
-# We want all ssh sesions to start in the /home directory
-echo "cd /home" >> ~/.profile
-
-# END: Configure ~/.profile
+# END: Configure /etc/profile
 
 # BEGIN: Process startup file / startup command, if any
 


### PR DESCRIPTION
- Currently, we only propagate a specific list of environment variables to the interactive sessions (ssh)
- This commit relaxes this behavior by propagating all environment variables to /etc/profile
- We now add variables to /etc/profile instead of ~/.profile to make it available not just to the interactive sessions, but also non-interactive sessions.