### PR TITLE
Fix broken paths in Dockerfile

### DIFF
--- a/8.5-java11/Dockerfile
+++ b/8.5-java11/Dockerfile
@@ -1,6 +1,6 @@
-################################################
-***DO NOT EDIT*** This is an auto-generated file
-################################################
+########################################################
+### ***DO NOT EDIT*** This is an auto-generated file ###
+########################################################
 ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine
 FROM $BASE_IMAGE
 
@@ -21,11 +21,11 @@ RUN rm -rf /usr/local/tomcat/webapps/
 # Remove the artifacts created by the base Java image, as we know we don't need them
 RUN rm -rf /tmp/webapps/
 
-COPY init_container.sh /bin/init_container.sh
-COPY web-easyauth-ai.xml /tmp/tomcat/conf/web-easyauth-ai.xml
-COPY index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
-COPY background.png /tmp/tomcat/webapps/ROOT/background.png
-COPY sshd_config /etc/ssh/
+COPY tmp/shared/tomcat/common/init_container.sh /bin/init_container.sh
+COPY tmp/shared/tomcat/8.5/web-appservice-ai.xml /tmp/tomcat/conf/web-appservice-ai.xml
+COPY tmp/shared/tomcat/common/index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
+COPY tmp/shared/tomcat/common/background.png /tmp/tomcat/webapps/ROOT/background.png
+COPY tmp/shared/tomcat/common/sshd_config /etc/ssh/
 COPY tmp/shared/app_insights/AI-Agent.xml /usr/local/app_insights/aiagent/
 COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tomcat_lib/
 
@@ -42,11 +42,11 @@ RUN apk add --update openssh-server bash openrc \
         && wget -O /usr/local/app_insights/aiagent/applicationinsights-agent-$AI_VERSION.jar https://github.com/Microsoft/ApplicationInsights-Java/releases/download/$AI_VERSION/applicationinsights-agent-$AI_VERSION.jar --no-verbose \
         && chmod 755 /bin/init_container.sh 
 
-COPY server.xml /usr/local/tomcat/conf/server.xml
-COPY catalina.properties /usr/local/tomcat/conf/catalina.properties
-COPY context.xml /usr/local/tomcat/conf/context.xml
-COPY logging.properties /usr/local/tomcat/conf/logging.properties
-COPY web-easyauth.xml /usr/local/tomcat/conf/web.xml
+COPY tmp/shared/tomcat/8.5/server.xml /usr/local/tomcat/conf/server.xml
+COPY tmp/shared/tomcat/8.5/catalina.properties /usr/local/tomcat/conf/catalina.properties
+COPY tmp/shared/tomcat/8.5/context.xml /usr/local/tomcat/conf/context.xml
+COPY tmp/shared/tomcat/8.5/logging.properties /usr/local/tomcat/conf/logging.properties
+COPY tmp/shared/tomcat/8.5/web-appservice.xml /usr/local/tomcat/conf/web.xml
 COPY tmp/shared/easyauth/azure.appservice.easyauth.jar /usr/local/tomcat/lib/
 COPY tmp/shared/appservice/azure.appservice.jar /usr/local/tomcat/lib/
 COPY tmp/shared/tomcat/bin/setenv.sh /usr/local/tomcat/bin/
@@ -54,7 +54,7 @@ COPY tmp/shared/tomcat/bin/setenv.sh /usr/local/tomcat/bin/
 EXPOSE 80 2222
 
 ENTRYPOINT ["/bin/init_container.sh"]
-################################################
-***DO NOT EDIT*** This is an auto-generated file
-################################################
+########################################################
+### ***DO NOT EDIT*** This is an auto-generated file ###
+########################################################
 

--- a/8.5-jre8/Dockerfile
+++ b/8.5-jre8/Dockerfile
@@ -1,6 +1,6 @@
-################################################
-***DO NOT EDIT*** This is an auto-generated file
-################################################
+########################################################
+### ***DO NOT EDIT*** This is an auto-generated file ###
+########################################################
 ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:8u202-zulu-alpine
 FROM $BASE_IMAGE
 
@@ -21,11 +21,11 @@ RUN rm -rf /usr/local/tomcat/webapps/
 # Remove the artifacts created by the base Java image, as we know we don't need them
 RUN rm -rf /tmp/webapps/
 
-COPY init_container.sh /bin/init_container.sh
-COPY web-easyauth-ai.xml /tmp/tomcat/conf/web-easyauth-ai.xml
-COPY index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
-COPY background.png /tmp/tomcat/webapps/ROOT/background.png
-COPY sshd_config /etc/ssh/
+COPY tmp/shared/tomcat/common/init_container.sh /bin/init_container.sh
+COPY tmp/shared/tomcat/8.5/web-appservice-ai.xml /tmp/tomcat/conf/web-appservice-ai.xml
+COPY tmp/shared/tomcat/common/index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
+COPY tmp/shared/tomcat/common/background.png /tmp/tomcat/webapps/ROOT/background.png
+COPY tmp/shared/tomcat/common/sshd_config /etc/ssh/
 COPY tmp/shared/app_insights/AI-Agent.xml /usr/local/app_insights/aiagent/
 COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tomcat_lib/
 
@@ -42,11 +42,11 @@ RUN apk add --update openssh-server bash openrc \
         && wget -O /usr/local/app_insights/aiagent/applicationinsights-agent-$AI_VERSION.jar https://github.com/Microsoft/ApplicationInsights-Java/releases/download/$AI_VERSION/applicationinsights-agent-$AI_VERSION.jar --no-verbose \
         && chmod 755 /bin/init_container.sh 
 
-COPY server.xml /usr/local/tomcat/conf/server.xml
-COPY catalina.properties /usr/local/tomcat/conf/catalina.properties
-COPY context.xml /usr/local/tomcat/conf/context.xml
-COPY logging.properties /usr/local/tomcat/conf/logging.properties
-COPY web-easyauth.xml /usr/local/tomcat/conf/web.xml
+COPY tmp/shared/tomcat/8.5/server.xml /usr/local/tomcat/conf/server.xml
+COPY tmp/shared/tomcat/8.5/catalina.properties /usr/local/tomcat/conf/catalina.properties
+COPY tmp/shared/tomcat/8.5/context.xml /usr/local/tomcat/conf/context.xml
+COPY tmp/shared/tomcat/8.5/logging.properties /usr/local/tomcat/conf/logging.properties
+COPY tmp/shared/tomcat/8.5/web-appservice.xml /usr/local/tomcat/conf/web.xml
 COPY tmp/shared/easyauth/azure.appservice.easyauth.jar /usr/local/tomcat/lib/
 COPY tmp/shared/appservice/azure.appservice.jar /usr/local/tomcat/lib/
 COPY tmp/shared/tomcat/bin/setenv.sh /usr/local/tomcat/bin/
@@ -54,7 +54,7 @@ COPY tmp/shared/tomcat/bin/setenv.sh /usr/local/tomcat/bin/
 EXPOSE 80 2222
 
 ENTRYPOINT ["/bin/init_container.sh"]
-################################################
-***DO NOT EDIT*** This is an auto-generated file
-################################################
+########################################################
+### ***DO NOT EDIT*** This is an auto-generated file ###
+########################################################
 

--- a/9.0-java11/Dockerfile
+++ b/9.0-java11/Dockerfile
@@ -1,6 +1,6 @@
-################################################
-***DO NOT EDIT*** This is an auto-generated file
-################################################
+########################################################
+### ***DO NOT EDIT*** This is an auto-generated file ###
+########################################################
 ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine
 FROM $BASE_IMAGE
 
@@ -21,11 +21,11 @@ RUN rm -rf /usr/local/tomcat/webapps/
 # Remove the artifacts created by the base Java image, as we know we don't need them
 RUN rm -rf /tmp/webapps/
 
-COPY init_container.sh /bin/init_container.sh
-COPY web-easyauth-ai.xml /tmp/tomcat/conf/web-easyauth-ai.xml
-COPY index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
-COPY background.png /tmp/tomcat/webapps/ROOT/background.png
-COPY sshd_config /etc/ssh/
+COPY tmp/shared/tomcat/common/init_container.sh /bin/init_container.sh
+COPY tmp/shared/tomcat/9.0/web-appservice-ai.xml /tmp/tomcat/conf/web-appservice-ai.xml
+COPY tmp/shared/tomcat/common/index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
+COPY tmp/shared/tomcat/common/background.png /tmp/tomcat/webapps/ROOT/background.png
+COPY tmp/shared/tomcat/common/sshd_config /etc/ssh/
 COPY tmp/shared/app_insights/AI-Agent.xml /usr/local/app_insights/aiagent/
 COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tomcat_lib/
 
@@ -42,11 +42,11 @@ RUN apk add --update openssh-server bash openrc \
         && wget -O /usr/local/app_insights/aiagent/applicationinsights-agent-$AI_VERSION.jar https://github.com/Microsoft/ApplicationInsights-Java/releases/download/$AI_VERSION/applicationinsights-agent-$AI_VERSION.jar --no-verbose \
         && chmod 755 /bin/init_container.sh 
 
-COPY server.xml /usr/local/tomcat/conf/server.xml
-COPY catalina.properties /usr/local/tomcat/conf/catalina.properties
-COPY context.xml /usr/local/tomcat/conf/context.xml
-COPY logging.properties /usr/local/tomcat/conf/logging.properties
-COPY web-easyauth.xml /usr/local/tomcat/conf/web.xml
+COPY tmp/shared/tomcat/9.0/server.xml /usr/local/tomcat/conf/server.xml
+COPY tmp/shared/tomcat/9.0/catalina.properties /usr/local/tomcat/conf/catalina.properties
+COPY tmp/shared/tomcat/9.0/context.xml /usr/local/tomcat/conf/context.xml
+COPY tmp/shared/tomcat/9.0/logging.properties /usr/local/tomcat/conf/logging.properties
+COPY tmp/shared/tomcat/9.0/web-appservice.xml /usr/local/tomcat/conf/web.xml
 COPY tmp/shared/easyauth/azure.appservice.easyauth.jar /usr/local/tomcat/lib/
 COPY tmp/shared/appservice/azure.appservice.jar /usr/local/tomcat/lib/
 COPY tmp/shared/tomcat/bin/setenv.sh /usr/local/tomcat/bin/
@@ -54,7 +54,7 @@ COPY tmp/shared/tomcat/bin/setenv.sh /usr/local/tomcat/bin/
 EXPOSE 80 2222
 
 ENTRYPOINT ["/bin/init_container.sh"]
-################################################
-***DO NOT EDIT*** This is an auto-generated file
-################################################
+########################################################
+### ***DO NOT EDIT*** This is an auto-generated file ###
+########################################################
 

--- a/9.0-jre8/Dockerfile
+++ b/9.0-jre8/Dockerfile
@@ -1,6 +1,6 @@
-################################################
-***DO NOT EDIT*** This is an auto-generated file
-################################################
+########################################################
+### ***DO NOT EDIT*** This is an auto-generated file ###
+########################################################
 ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:8u202-zulu-alpine
 FROM $BASE_IMAGE
 
@@ -21,11 +21,11 @@ RUN rm -rf /usr/local/tomcat/webapps/
 # Remove the artifacts created by the base Java image, as we know we don't need them
 RUN rm -rf /tmp/webapps/
 
-COPY init_container.sh /bin/init_container.sh
-COPY web-easyauth-ai.xml /tmp/tomcat/conf/web-easyauth-ai.xml
-COPY index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
-COPY background.png /tmp/tomcat/webapps/ROOT/background.png
-COPY sshd_config /etc/ssh/
+COPY tmp/shared/tomcat/common/init_container.sh /bin/init_container.sh
+COPY tmp/shared/tomcat/9.0/web-appservice-ai.xml /tmp/tomcat/conf/web-appservice-ai.xml
+COPY tmp/shared/tomcat/common/index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
+COPY tmp/shared/tomcat/common/background.png /tmp/tomcat/webapps/ROOT/background.png
+COPY tmp/shared/tomcat/common/sshd_config /etc/ssh/
 COPY tmp/shared/app_insights/AI-Agent.xml /usr/local/app_insights/aiagent/
 COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tomcat_lib/
 
@@ -42,11 +42,11 @@ RUN apk add --update openssh-server bash openrc \
         && wget -O /usr/local/app_insights/aiagent/applicationinsights-agent-$AI_VERSION.jar https://github.com/Microsoft/ApplicationInsights-Java/releases/download/$AI_VERSION/applicationinsights-agent-$AI_VERSION.jar --no-verbose \
         && chmod 755 /bin/init_container.sh 
 
-COPY server.xml /usr/local/tomcat/conf/server.xml
-COPY catalina.properties /usr/local/tomcat/conf/catalina.properties
-COPY context.xml /usr/local/tomcat/conf/context.xml
-COPY logging.properties /usr/local/tomcat/conf/logging.properties
-COPY web-easyauth.xml /usr/local/tomcat/conf/web.xml
+COPY tmp/shared/tomcat/9.0/server.xml /usr/local/tomcat/conf/server.xml
+COPY tmp/shared/tomcat/9.0/catalina.properties /usr/local/tomcat/conf/catalina.properties
+COPY tmp/shared/tomcat/9.0/context.xml /usr/local/tomcat/conf/context.xml
+COPY tmp/shared/tomcat/9.0/logging.properties /usr/local/tomcat/conf/logging.properties
+COPY tmp/shared/tomcat/9.0/web-appservice.xml /usr/local/tomcat/conf/web.xml
 COPY tmp/shared/easyauth/azure.appservice.easyauth.jar /usr/local/tomcat/lib/
 COPY tmp/shared/appservice/azure.appservice.jar /usr/local/tomcat/lib/
 COPY tmp/shared/tomcat/bin/setenv.sh /usr/local/tomcat/bin/
@@ -54,7 +54,7 @@ COPY tmp/shared/tomcat/bin/setenv.sh /usr/local/tomcat/bin/
 EXPOSE 80 2222
 
 ENTRYPOINT ["/bin/init_container.sh"]
-################################################
-***DO NOT EDIT*** This is an auto-generated file
-################################################
+########################################################
+### ***DO NOT EDIT*** This is an auto-generated file ###
+########################################################
 

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -11,8 +11,7 @@ function setup
 
     # Copy the shared files to the target directory
     copy-item -recurse shared $dirpath
-    copy-item -recurse shared\tomcat\common\* $version
-
+    
     $dockerFileTemplatePath = '.\shared\tomcat\common\Dockerfile'
     $dockerFileOutPath = "$version\Dockerfile"
 
@@ -22,49 +21,49 @@ function setup
     {
         '8.5-jre8'
         {
-        	copy-item -recurse shared\tomcat\8.5\* $version
             $content = ((Get-Content -path $dockerFileTemplatePath -Raw) `
                 -replace '__PLACEHOLDER_BASEIMAGE__','mcr.microsoft.com/java/jre-headless:8u202-zulu-alpine') `
                 -replace '__PLACEHOLDER_AI_VERSION__','2.1.2' `
                 -replace '__PLACEHOLDER_TOMCAT_VERSION__','8.5.35' `
-                -replace '__PLACEHOLDER_TOMCAT_MAJOR__','8'
+                -replace '__PLACEHOLDER_TOMCAT_MAJOR__','8' `
+                -replace '__PLACEHOLDER_TOMCAT_MAJOR_MINOR__', '8.5'
             break
         }
 
         '8.5-java11'
         {
-        	copy-item -recurse shared\tomcat\8.5\* $version
             $content = ((Get-Content -path $dockerFileTemplatePath -Raw) `
                 -replace '__PLACEHOLDER_BASEIMAGE__','mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine') `
                 -replace '__PLACEHOLDER_AI_VERSION__','2.1.2' `
                 -replace '__PLACEHOLDER_TOMCAT_VERSION__','8.5.35' `
-                -replace '__PLACEHOLDER_TOMCAT_MAJOR__','8' 
+                -replace '__PLACEHOLDER_TOMCAT_MAJOR__','8' `
+                -replace '__PLACEHOLDER_TOMCAT_MAJOR_MINOR__', '8.5' 
             break
         }
 
         '9.0-jre8'
         {
-        	copy-item -recurse shared\tomcat\9.0\* $version
             $content = ((Get-Content -path $dockerFileTemplatePath -Raw) `
                 -replace '__PLACEHOLDER_BASEIMAGE__','mcr.microsoft.com/java/jre-headless:8u202-zulu-alpine') `
                 -replace '__PLACEHOLDER_AI_VERSION__','2.1.2' `
                 -replace '__PLACEHOLDER_TOMCAT_VERSION__','9.0.13' `
-                -replace '__PLACEHOLDER_TOMCAT_MAJOR__','9'
+                -replace '__PLACEHOLDER_TOMCAT_MAJOR__','9' `
+                -replace '__PLACEHOLDER_TOMCAT_MAJOR_MINOR__', '9.0'
             break
         }
 
         '9.0-java11'
         {
-        	copy-item -recurse shared\tomcat\9.0\* $version
             $content = ((Get-Content -path $dockerFileTemplatePath -Raw) `
                 -replace '__PLACEHOLDER_BASEIMAGE__','mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine') `
                 -replace '__PLACEHOLDER_AI_VERSION__','2.1.2' `
                 -replace '__PLACEHOLDER_TOMCAT_VERSION__','9.0.13' `
-                -replace '__PLACEHOLDER_TOMCAT_MAJOR__','9'
+                -replace '__PLACEHOLDER_TOMCAT_MAJOR__','9' `
+                -replace '__PLACEHOLDER_TOMCAT_MAJOR_MINOR__', '9.0'
             break
         }
     }
-    $headerFooter = "################################################`n***DO NOT EDIT*** This is an auto-generated file`n################################################`n"
+    $headerFooter = "########################################################`n### ***DO NOT EDIT*** This is an auto-generated file ###`n########################################################`n"
     $content = $headerFooter + $content + $headerFooter
     Set-Content -Value $content -Path $dockerFileOutPath
 }

--- a/shared/tomcat/common/Dockerfile
+++ b/shared/tomcat/common/Dockerfile
@@ -18,11 +18,11 @@ RUN rm -rf /usr/local/tomcat/webapps/
 # Remove the artifacts created by the base Java image, as we know we don't need them
 RUN rm -rf /tmp/webapps/
 
-COPY init_container.sh /bin/init_container.sh
-COPY web-easyauth-ai.xml /tmp/tomcat/conf/web-easyauth-ai.xml
-COPY index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
-COPY background.png /tmp/tomcat/webapps/ROOT/background.png
-COPY sshd_config /etc/ssh/
+COPY tmp/shared/tomcat/common/init_container.sh /bin/init_container.sh
+COPY tmp/shared/tomcat/__PLACEHOLDER_TOMCAT_MAJOR_MINOR__/web-appservice-ai.xml /tmp/tomcat/conf/web-appservice-ai.xml
+COPY tmp/shared/tomcat/common/index.jsp /tmp/tomcat/webapps/ROOT/index.jsp
+COPY tmp/shared/tomcat/common/background.png /tmp/tomcat/webapps/ROOT/background.png
+COPY tmp/shared/tomcat/common/sshd_config /etc/ssh/
 COPY tmp/shared/app_insights/AI-Agent.xml /usr/local/app_insights/aiagent/
 COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tomcat_lib/
 
@@ -39,11 +39,11 @@ RUN apk add --update openssh-server bash openrc \
         && wget -O /usr/local/app_insights/aiagent/applicationinsights-agent-$AI_VERSION.jar https://github.com/Microsoft/ApplicationInsights-Java/releases/download/$AI_VERSION/applicationinsights-agent-$AI_VERSION.jar --no-verbose \
         && chmod 755 /bin/init_container.sh 
 
-COPY server.xml /usr/local/tomcat/conf/server.xml
-COPY catalina.properties /usr/local/tomcat/conf/catalina.properties
-COPY context.xml /usr/local/tomcat/conf/context.xml
-COPY logging.properties /usr/local/tomcat/conf/logging.properties
-COPY web-easyauth.xml /usr/local/tomcat/conf/web.xml
+COPY tmp/shared/tomcat/__PLACEHOLDER_TOMCAT_MAJOR_MINOR__/server.xml /usr/local/tomcat/conf/server.xml
+COPY tmp/shared/tomcat/__PLACEHOLDER_TOMCAT_MAJOR_MINOR__/catalina.properties /usr/local/tomcat/conf/catalina.properties
+COPY tmp/shared/tomcat/__PLACEHOLDER_TOMCAT_MAJOR_MINOR__/context.xml /usr/local/tomcat/conf/context.xml
+COPY tmp/shared/tomcat/__PLACEHOLDER_TOMCAT_MAJOR_MINOR__/logging.properties /usr/local/tomcat/conf/logging.properties
+COPY tmp/shared/tomcat/__PLACEHOLDER_TOMCAT_MAJOR_MINOR__/web-appservice.xml /usr/local/tomcat/conf/web.xml
 COPY tmp/shared/easyauth/azure.appservice.easyauth.jar /usr/local/tomcat/lib/
 COPY tmp/shared/appservice/azure.appservice.jar /usr/local/tomcat/lib/
 COPY tmp/shared/tomcat/bin/setenv.sh /usr/local/tomcat/bin/

--- a/shared/tomcat/common/init_container.sh
+++ b/shared/tomcat/common/init_container.sh
@@ -65,7 +65,7 @@ then
     echo "Initializing App Insights.."
     export CATALINA_OPTS=-javaagent:/usr/local/app_insights/aiagent/applicationinsights-agent-$AI_VERSION.jar $CATALINA_OPTS
     mv /usr/local/app_insights/tomcat_lib/* /usr/local/tomcat/lib/
-    mv /tmp/tomcat/conf/web-easyauth-ai.xml /usr/local/tomcat/conf/web.xml
+    mv /tmp/tomcat/conf/web-appservice-ai.xml /usr/local/tomcat/conf/web.xml
 else
     echo "Skipping App Insights initialization"
 fi


### PR DESCRIPTION
- An earlier commit changed the setup.ps1 script, which copies a few files to the tmp directory instead of the earlier paths
- This commit fixes the paths in the Dockerfile accordingly