### PR TITLE
Fix warnings / errors during container startup

### DIFF
--- a/8.5-java11/Dockerfile
+++ b/8.5-java11/Dockerfile
@@ -31,6 +31,16 @@ COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tom
 
 RUN apk add --update openssh-server bash openrc \
         && rm -rf /var/cache/apk/* \
+        # Remove unnecessary services
+        && rm -f /etc/init.d/hwdrivers \
+                 /etc/init.d/hwclock \
+                 /etc/init.d/mtab \
+                 /etc/init.d/bootmisc \
+                 /etc/init.d/modules \
+                 /etc/init.d/modules-load \
+                 /etc/init.d/modloop \
+        # Can't do cgroups
+        && sed -i 's/\tcgroup_add_service/\t#cgroup_add_service/g' /lib/rc/sh/openrc-run.sh \
         && echo "root:Docker!" | chpasswd \
         && wget -O /tmp/apache-tomcat-$TOMCAT_VERSION.tar.gz https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz --no-verbose \
         && tar xvzf /tmp/apache-tomcat-$TOMCAT_VERSION.tar.gz -C /tmp \

--- a/8.5-jre8/Dockerfile
+++ b/8.5-jre8/Dockerfile
@@ -31,6 +31,16 @@ COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tom
 
 RUN apk add --update openssh-server bash openrc \
         && rm -rf /var/cache/apk/* \
+        # Remove unnecessary services
+        && rm -f /etc/init.d/hwdrivers \
+                 /etc/init.d/hwclock \
+                 /etc/init.d/mtab \
+                 /etc/init.d/bootmisc \
+                 /etc/init.d/modules \
+                 /etc/init.d/modules-load \
+                 /etc/init.d/modloop \
+        # Can't do cgroups
+        && sed -i 's/\tcgroup_add_service/\t#cgroup_add_service/g' /lib/rc/sh/openrc-run.sh \
         && echo "root:Docker!" | chpasswd \
         && wget -O /tmp/apache-tomcat-$TOMCAT_VERSION.tar.gz https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz --no-verbose \
         && tar xvzf /tmp/apache-tomcat-$TOMCAT_VERSION.tar.gz -C /tmp \

--- a/9.0-java11/Dockerfile
+++ b/9.0-java11/Dockerfile
@@ -31,6 +31,16 @@ COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tom
 
 RUN apk add --update openssh-server bash openrc \
         && rm -rf /var/cache/apk/* \
+        # Remove unnecessary services
+        && rm -f /etc/init.d/hwdrivers \
+                 /etc/init.d/hwclock \
+                 /etc/init.d/mtab \
+                 /etc/init.d/bootmisc \
+                 /etc/init.d/modules \
+                 /etc/init.d/modules-load \
+                 /etc/init.d/modloop \
+        # Can't do cgroups
+        && sed -i 's/\tcgroup_add_service/\t#cgroup_add_service/g' /lib/rc/sh/openrc-run.sh \
         && echo "root:Docker!" | chpasswd \
         && wget -O /tmp/apache-tomcat-$TOMCAT_VERSION.tar.gz https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz --no-verbose \
         && tar xvzf /tmp/apache-tomcat-$TOMCAT_VERSION.tar.gz -C /tmp \

--- a/9.0-jre8/Dockerfile
+++ b/9.0-jre8/Dockerfile
@@ -31,6 +31,16 @@ COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tom
 
 RUN apk add --update openssh-server bash openrc \
         && rm -rf /var/cache/apk/* \
+        # Remove unnecessary services
+        && rm -f /etc/init.d/hwdrivers \
+                 /etc/init.d/hwclock \
+                 /etc/init.d/mtab \
+                 /etc/init.d/bootmisc \
+                 /etc/init.d/modules \
+                 /etc/init.d/modules-load \
+                 /etc/init.d/modloop \
+        # Can't do cgroups
+        && sed -i 's/\tcgroup_add_service/\t#cgroup_add_service/g' /lib/rc/sh/openrc-run.sh \
         && echo "root:Docker!" | chpasswd \
         && wget -O /tmp/apache-tomcat-$TOMCAT_VERSION.tar.gz https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz --no-verbose \
         && tar xvzf /tmp/apache-tomcat-$TOMCAT_VERSION.tar.gz -C /tmp \

--- a/shared/tomcat/common/Dockerfile
+++ b/shared/tomcat/common/Dockerfile
@@ -28,6 +28,16 @@ COPY tmp/shared/app_insights/ApplicationInsights.xml /usr/local/app_insights/tom
 
 RUN apk add --update openssh-server bash openrc \
         && rm -rf /var/cache/apk/* \
+        # Remove unnecessary services
+        && rm -f /etc/init.d/hwdrivers \
+                 /etc/init.d/hwclock \
+                 /etc/init.d/mtab \
+                 /etc/init.d/bootmisc \
+                 /etc/init.d/modules \
+                 /etc/init.d/modules-load \
+                 /etc/init.d/modloop \
+        # Can't do cgroups
+        && sed -i 's/\tcgroup_add_service/\t#cgroup_add_service/g' /lib/rc/sh/openrc-run.sh \
         && echo "root:Docker!" | chpasswd \
         && wget -O /tmp/apache-tomcat-$TOMCAT_VERSION.tar.gz https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz --no-verbose \
         && tar xvzf /tmp/apache-tomcat-$TOMCAT_VERSION.tar.gz -C /tmp \


### PR DESCRIPTION
- There are a bunch of warnings / errors emitted at the time of starting the container. These are commonly encountered errors by the developer community when using alpine images
- This commit contains tweaks to disable services / features that are not needed by App Service
- Most of the tweaks done as part of the commit are shared on various forums as a workaround, while some were added based on the errors seen while running the container
- The workarounds disable only the services and functionality not needed by App Service