### PR TITLE
Make /home the default directory for ssh sessions

### DIFF
--- a/shared/tomcat/common/init_container.sh
+++ b/shared/tomcat/common/init_container.sh
@@ -97,6 +97,9 @@ export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Djava.net.preferIPv4Stack=true"
 
 eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/g' | sed '/=/s//="/' | sed 's/$/"/' >> /etc/profile)
 
+# We want all ssh sesions to start in the /home directory
+echo "cd /home" >> /etc/profile
+
 # END: Configure /etc/profile
 
 # BEGIN: Process startup file / startup command, if any


### PR DESCRIPTION
- An earlier commit accidentally removed the "cd /home" from ~/.profile. With this change we are adding it back.
- Instead of adding it to ~/.profile we are now adding it to /etc/profile as we have moved away from ~/.profile to /etc/profile in an earlier change.
- By default (in the absence of this change), an ssh session would start in the /root directory, which is not what we want.
- With this commit, /home will be the default directory for all ssh sessions