### PR TITLE
Add read access for others to consume log files

### DIFF
--- a/shared/tomcat/bin/setenv.sh
+++ b/shared/tomcat/bin/setenv.sh
@@ -1,7 +1,7 @@
 ##### This file will be called from catalina.sh #####
 
 # Starting tomcat 8.5, by default the files created by tomcat doesn’t grant read access to “others”, this includes log files.
-# Override Tomcat's default UMASK of 0027 (rw-r-----) with 0022 (-rw-r--r--) for td-agent on host to read log files (AzMon)
+# Override Tomcat's default UMASK of 0027 (rw-r-----) with 0022 (-rw-r--r--).
 export UMASK="0022"
 
 # Any changes to JUL needs to be loaded at system level. https://tomcat.apache.org/tomcat-9.0-doc/class-loader-howto.html

--- a/shared/tomcat/bin/setenv.sh
+++ b/shared/tomcat/bin/setenv.sh
@@ -1,3 +1,10 @@
+##### This file will be called from catalina.sh #####
+
+# Starting tomcat 8.5, by default the files created by tomcat doesn’t grant read access to “others”, this includes logs file.
+# Override Tomcat's default UMASK of 0027 (rw-r-----) with 0022 (-rw-r--r--) so that td-agent on host can read log files (AzMon)
+export UMASK="0022"
+
 # Any changes to JUL needs to be loaded at system level. https://tomcat.apache.org/tomcat-9.0-doc/class-loader-howto.html
-# tThis file will be called from catalina.sh
+# Loading the Az-Mon formatter
 CLASSPATH=$CATALINA_BASE/lib/servlet-api.jar:$CATALINA_BASE/lib/azure.appservice.jar
+

--- a/shared/tomcat/bin/setenv.sh
+++ b/shared/tomcat/bin/setenv.sh
@@ -1,10 +1,9 @@
 ##### This file will be called from catalina.sh #####
 
-# Starting tomcat 8.5, by default the files created by tomcat doesn’t grant read access to “others”, this includes logs file.
-# Override Tomcat's default UMASK of 0027 (rw-r-----) with 0022 (-rw-r--r--) so that td-agent on host can read log files (AzMon)
+# Starting tomcat 8.5, by default the files created by tomcat doesn’t grant read access to “others”, this includes log files.
+# Override Tomcat's default UMASK of 0027 (rw-r-----) with 0022 (-rw-r--r--) for td-agent on host to read log files (AzMon)
 export UMASK="0022"
 
 # Any changes to JUL needs to be loaded at system level. https://tomcat.apache.org/tomcat-9.0-doc/class-loader-howto.html
 # Loading the Az-Mon formatter
 CLASSPATH=$CATALINA_BASE/lib/servlet-api.jar:$CATALINA_BASE/lib/azure.appservice.jar
-


### PR DESCRIPTION
# Starting tomcat 8.5, by default the files created by tomcat doesn’t grant read access to “others”, this includes logs file.
# Override Tomcat's default UMASK of 0027 (rw-r-----) with 0022 (-rw-r--r--) so that td-agent on host can read log files (AzMon)