### PR TITLE
Change URI encoding to UTF-8

### DIFF
--- a/shared/tomcat/8.5/server.xml
+++ b/shared/tomcat/8.5/server.xml
@@ -72,6 +72,7 @@
                connectionTimeout="20000"
                redirectPort="8443"
                compression="on"
+               URIEncoding="UTF-8"
                maxHttpHeaderSize="16384" />
     <!-- A "Connector" using the shared thread pool-->
     <!--

--- a/shared/tomcat/9.0/server.xml
+++ b/shared/tomcat/9.0/server.xml
@@ -72,6 +72,7 @@
                connectionTimeout="20000"
                redirectPort="8443"
                compression="on"
+               URIEncoding="UTF-8"
                maxHttpHeaderSize="16384" />
     <!-- A "Connector" using the shared thread pool-->
     <!--


### PR DESCRIPTION
- Refer https://stackoverflow.com/questions/27400671/utf-8-in-java-servlet-doesnt-work-when-deployed-to-azure-websites for more details of why this change is being made. Summary: Special characters aren't working as expected.
- Refer https://wiki.apache.org/tomcat/FAQ/CharacterEncoding for more details of the URIEncoding attribute