### PR TITLE
Define a GIT_COMMIT build argument

### DIFF
--- a/8.5-java11/Dockerfile
+++ b/8.5-java11/Dockerfile
@@ -2,13 +2,18 @@
 ### ***DO NOT EDIT*** This is an auto-generated file ###
 ########################################################
 ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine
+ARG GIT_COMMIT=unspecified
 FROM $BASE_IMAGE
+
+# Re-define ARG to make the build argument available for use in the rest of the Dockerfile
+ARG GIT_COMMIT
 
 LABEL maintainer="Azure App Services Container Images <appsvc-images@microsoft.com>"
 
 ENV AI_VERSION 2.1.2
 ENV TOMCAT_VERSION 8.5.38
 ENV TOMCAT_MAJOR 8
+ENV GIT_COMMIT $GIT_COMMIT
 
 ENV PORT 80
 ENV SSH_PORT 2222

--- a/8.5-jre8/Dockerfile
+++ b/8.5-jre8/Dockerfile
@@ -2,13 +2,18 @@
 ### ***DO NOT EDIT*** This is an auto-generated file ###
 ########################################################
 ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:8u202-zulu-alpine
+ARG GIT_COMMIT=unspecified
 FROM $BASE_IMAGE
+
+# Re-define ARG to make the build argument available for use in the rest of the Dockerfile
+ARG GIT_COMMIT
 
 LABEL maintainer="Azure App Services Container Images <appsvc-images@microsoft.com>"
 
 ENV AI_VERSION 2.1.2
 ENV TOMCAT_VERSION 8.5.38
 ENV TOMCAT_MAJOR 8
+ENV GIT_COMMIT $GIT_COMMIT
 
 ENV PORT 80
 ENV SSH_PORT 2222

--- a/9.0-java11/Dockerfile
+++ b/9.0-java11/Dockerfile
@@ -2,13 +2,18 @@
 ### ***DO NOT EDIT*** This is an auto-generated file ###
 ########################################################
 ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:11u2-zulu-alpine
+ARG GIT_COMMIT=unspecified
 FROM $BASE_IMAGE
+
+# Re-define ARG to make the build argument available for use in the rest of the Dockerfile
+ARG GIT_COMMIT
 
 LABEL maintainer="Azure App Services Container Images <appsvc-images@microsoft.com>"
 
 ENV AI_VERSION 2.1.2
 ENV TOMCAT_VERSION 9.0.16
 ENV TOMCAT_MAJOR 9
+ENV GIT_COMMIT $GIT_COMMIT
 
 ENV PORT 80
 ENV SSH_PORT 2222

--- a/9.0-jre8/Dockerfile
+++ b/9.0-jre8/Dockerfile
@@ -2,13 +2,18 @@
 ### ***DO NOT EDIT*** This is an auto-generated file ###
 ########################################################
 ARG BASE_IMAGE=mcr.microsoft.com/java/jre-headless:8u202-zulu-alpine
+ARG GIT_COMMIT=unspecified
 FROM $BASE_IMAGE
+
+# Re-define ARG to make the build argument available for use in the rest of the Dockerfile
+ARG GIT_COMMIT
 
 LABEL maintainer="Azure App Services Container Images <appsvc-images@microsoft.com>"
 
 ENV AI_VERSION 2.1.2
 ENV TOMCAT_VERSION 9.0.16
 ENV TOMCAT_MAJOR 9
+ENV GIT_COMMIT $GIT_COMMIT
 
 ENV PORT 80
 ENV SSH_PORT 2222

--- a/shared/tomcat/common/Dockerfile
+++ b/shared/tomcat/common/Dockerfile
@@ -1,11 +1,16 @@
 ARG BASE_IMAGE=__PLACEHOLDER_BASEIMAGE__
+ARG GIT_COMMIT=unspecified
 FROM $BASE_IMAGE
+
+# Re-define ARG to make the build argument available for use in the rest of the Dockerfile
+ARG GIT_COMMIT
 
 LABEL maintainer="Azure App Services Container Images <appsvc-images@microsoft.com>"
 
 ENV AI_VERSION __PLACEHOLDER_AI_VERSION__
 ENV TOMCAT_VERSION __PLACEHOLDER_TOMCAT_VERSION__
 ENV TOMCAT_MAJOR __PLACEHOLDER_TOMCAT_MAJOR__
+ENV GIT_COMMIT $GIT_COMMIT
 
 ENV PORT 80
 ENV SSH_PORT 2222


### PR DESCRIPTION
- This helps specify (optionally) the git commit id that was used to generate the image