### PR TITLE
Pull the latest image before building

### DIFF
--- a/scripts/publishStage1.ps1
+++ b/scripts/publishStage1.ps1
@@ -26,7 +26,7 @@ function Build
 
     Write-Host -ForegroundColor Green Building $image
 
-    $buildcmd = "docker build --no-cache --build-arg GIT_COMMIT=$gitcommit -t $image $directory"
+    $buildcmd = "docker build --pull --no-cache --build-arg GIT_COMMIT=$gitcommit -t $image $directory"
     Write-Host -ForegroundColor Green $buildcmd
 
     # Run the build command


### PR DESCRIPTION
- Use "docker build --pull" to be sure that the build is not performed using a previously pulled image as the base image may have changed since then