### PR TITLE
Make dependencies of azure.appservice.jar available to the System class loader

### DIFF
--- a/shared/tomcat/bin/setenv.sh
+++ b/shared/tomcat/bin/setenv.sh
@@ -4,6 +4,14 @@
 # Override Tomcat's default UMASK of 0027 (rw-r-----) with 0022 (-rw-r--r--).
 export UMASK="0022"
 
-# Any changes to JUL needs to be loaded at system level. https://tomcat.apache.org/tomcat-9.0-doc/class-loader-howto.html
-# Loading the Az-Mon formatter
-CLASSPATH=$CATALINA_BASE/lib/azure.appservice.jar
+# JARs added to $CATALINA_HOME/lib (and other paths supported by the Common class loader) are available for use by Tomcat.
+# However, tomcat-juli.jar (which contains Tomcat's enhancements to java.util.logging) is loaded by the System class 
+# loader, not the Common class loader. Refer https://tomcat.apache.org/tomcat-9.0-doc/class-loader-howto.html for more details.
+#
+# As azure.appservice.jar contains formatters that tomcat-juli.jar needs to see, azure.appservice.jar needs to be added to
+# a path supported by the System class loader, not the Common class loader. This implies that we need to make all dependencies
+# of azure.appservice.jar available to System class loader as well.
+#
+# To make jars available to System class loader, they need to be added to CLASSPATH in setenv.sh (this file).
+# Update the CLASSPATH to load the AzMon formatter jar and its dependency servlet-api.jar.
+CLASSPATH=$CATALINA_BASE/lib/servlet-api.jar:$CATALINA_BASE/lib/azure.appservice.jar


### PR DESCRIPTION
- This commit reverts an earlier change by adding servlet-api.jar to the classpath again. The earlier change removed servlet-api.jar from the classpath as it is already available to the Common class loader ($CATALINA_HOME/lib/*.jar)
- However, the logger jar is loaded by System class loader which does not load classes in $CATALINA_HOME/lib. So we need to make sure that the dependencies of the logger jar are available to the System class loader.
- Refer comments in setenv.sh for more details