### PR TITLE
Copy web app to a local location before running

### DIFF
--- a/8.5-java11/Dockerfile
+++ b/8.5-java11/Dockerfile
@@ -24,9 +24,6 @@ ENV PATH /usr/local/tomcat/bin:$PATH
 # Remove the sample webapps provided by Tomcat
 RUN rm -rf /usr/local/tomcat/webapps/
 
-# Remove the artifacts created by the base Java image, as we know we don't need them
-RUN rm -rf /tmp/webapps/
-
 COPY tmp/shared/misc/init_container.sh /bin/init_container.sh
 COPY tmp/shared/tomcat/8.5/web-appservice-ai.xml /tmp/tomcat/conf/web-appservice-ai.xml
 COPY tmp/shared/misc/index.jsp /tmp/tomcat/webapps/ROOT/index.jsp

--- a/8.5-jre8/Dockerfile
+++ b/8.5-jre8/Dockerfile
@@ -24,9 +24,6 @@ ENV PATH /usr/local/tomcat/bin:$PATH
 # Remove the sample webapps provided by Tomcat
 RUN rm -rf /usr/local/tomcat/webapps/
 
-# Remove the artifacts created by the base Java image, as we know we don't need them
-RUN rm -rf /tmp/webapps/
-
 COPY tmp/shared/misc/init_container.sh /bin/init_container.sh
 COPY tmp/shared/tomcat/8.5/web-appservice-ai.xml /tmp/tomcat/conf/web-appservice-ai.xml
 COPY tmp/shared/misc/index.jsp /tmp/tomcat/webapps/ROOT/index.jsp

--- a/9.0-java11/Dockerfile
+++ b/9.0-java11/Dockerfile
@@ -24,9 +24,6 @@ ENV PATH /usr/local/tomcat/bin:$PATH
 # Remove the sample webapps provided by Tomcat
 RUN rm -rf /usr/local/tomcat/webapps/
 
-# Remove the artifacts created by the base Java image, as we know we don't need them
-RUN rm -rf /tmp/webapps/
-
 COPY tmp/shared/misc/init_container.sh /bin/init_container.sh
 COPY tmp/shared/tomcat/9.0/web-appservice-ai.xml /tmp/tomcat/conf/web-appservice-ai.xml
 COPY tmp/shared/misc/index.jsp /tmp/tomcat/webapps/ROOT/index.jsp

--- a/9.0-jre8/Dockerfile
+++ b/9.0-jre8/Dockerfile
@@ -24,9 +24,6 @@ ENV PATH /usr/local/tomcat/bin:$PATH
 # Remove the sample webapps provided by Tomcat
 RUN rm -rf /usr/local/tomcat/webapps/
 
-# Remove the artifacts created by the base Java image, as we know we don't need them
-RUN rm -rf /tmp/webapps/
-
 COPY tmp/shared/misc/init_container.sh /bin/init_container.sh
 COPY tmp/shared/tomcat/9.0/web-appservice-ai.xml /tmp/tomcat/conf/web-appservice-ai.xml
 COPY tmp/shared/misc/index.jsp /tmp/tomcat/webapps/ROOT/index.jsp

--- a/shared/misc/Dockerfile
+++ b/shared/misc/Dockerfile
@@ -21,9 +21,6 @@ ENV PATH /usr/local/tomcat/bin:$PATH
 # Remove the sample webapps provided by Tomcat
 RUN rm -rf /usr/local/tomcat/webapps/
 
-# Remove the artifacts created by the base Java image, as we know we don't need them
-RUN rm -rf /tmp/webapps/
-
 COPY tmp/shared/misc/init_container.sh /bin/init_container.sh
 COPY tmp/shared/tomcat/__PLACEHOLDER_TOMCAT_MAJOR_MINOR__/web-appservice-ai.xml /tmp/tomcat/conf/web-appservice-ai.xml
 COPY tmp/shared/misc/index.jsp /tmp/tomcat/webapps/ROOT/index.jsp

--- a/shared/misc/init_container.sh
+++ b/shared/misc/init_container.sh
@@ -37,10 +37,12 @@ then
     export CATALINA_BASE=
 fi
 
+# If no app is published at /home/site/wwwroot/webapps, use the parking page app
 if [ ! -d /home/site/wwwroot/webapps ]
 then
-    mkdir -p /home/site/wwwroot
-    cp -r /tmp/tomcat/webapps /home/site/wwwroot
+    cp -r /tmp/tomcat/webapps /usr/local/tomcat/webapps
+else
+    cp -r /home/site/wwwroot/webapps /usr/local/tomcat/webapps
 fi
 
 # COMPUTERNAME will be defined uniquely for each worker instance while running in Azure.

--- a/shared/tomcat/8.5/server.xml
+++ b/shared/tomcat/8.5/server.xml
@@ -145,7 +145,7 @@
                resourceName="UserDatabase"/>
       </Realm>
 
-      <Host name="localhost" appBase="${site.home}/site/wwwroot/webapps" xmlBase="${site.home}/site/wwwroot/"
+      <Host name="localhost" appBase="webapps"
             unpackWARs="false" autoDeploy="true" workDir="${site.tempdir}">
 
         <!-- SingleSignOn valve, share authentication between web applications

--- a/shared/tomcat/9.0/server.xml
+++ b/shared/tomcat/9.0/server.xml
@@ -145,7 +145,7 @@
                resourceName="UserDatabase"/>
       </Realm>
 
-      <Host name="localhost" appBase="${site.home}/site/wwwroot/webapps" xmlBase="${site.home}/site/wwwroot/"
+      <Host name="localhost" appBase="webapps"
             unpackWARs="false" autoDeploy="true" workDir="${site.tempdir}">
 
         <!-- SingleSignOn valve, share authentication between web applications


### PR DESCRIPTION
- Copy the /home/site/wwwroot/webapps directory to /usr/local/tomcat/webapps before starting Tomcat, so that the app runs locally.
- New deployments would trigger a container recycle as the container watches the wardeploy marker file (/home/site/deployments/active).