### PR TITLE
Skip local copy if WEBSITE_SKIP_LOCAL_COPY is 1 or TRUE

### DIFF
--- a/shared/tomcat/8.5/server.xml
+++ b/shared/tomcat/8.5/server.xml
@@ -145,7 +145,7 @@
                resourceName="UserDatabase"/>
       </Realm>
 
-      <Host name="localhost" appBase="webapps"
+      <Host name="localhost" appBase="${site.root}"
             unpackWARs="false" autoDeploy="true" workDir="${site.tempdir}">
 
         <!-- SingleSignOn valve, share authentication between web applications

--- a/shared/tomcat/9.0/server.xml
+++ b/shared/tomcat/9.0/server.xml
@@ -145,7 +145,7 @@
                resourceName="UserDatabase"/>
       </Realm>
 
-      <Host name="localhost" appBase="webapps"
+      <Host name="localhost" appBase="${site.root}"
             unpackWARs="false" autoDeploy="true" workDir="${site.tempdir}">
 
         <!-- SingleSignOn valve, share authentication between web applications


### PR DESCRIPTION
- Skip local copying of the application if WEBSITE_SKIP_LOCAL_COPY is set to 1 or true (case insensitive) or if Local cache is enabled (in which case copying the app again is unnecessary)
- Also, enable case-insensitive string comparisons at the very beginning in init_container.sh