### PR TITLE
Log ActivityID in the site access logs

### DIFF
--- a/shared/tomcat/8.5/server.xml
+++ b/shared/tomcat/8.5/server.xml
@@ -159,7 +159,7 @@
              Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="${site.logdir}/http/RawLogs"
                prefix="site_access_log.${catalina.instance.name}" suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b %D" />
+               pattern="%h %l %u %t &quot;%r&quot; %s %b %D %{x-arr-log-id}i" />
 
       </Host>
     </Engine>

--- a/shared/tomcat/9.0/server.xml
+++ b/shared/tomcat/9.0/server.xml
@@ -159,7 +159,7 @@
              Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="${site.logdir}/http/RawLogs"
                prefix="site_access_log.${catalina.instance.name}" suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b %D" />
+               pattern="%h %l %u %t &quot;%r&quot; %s %b %D %{x-arr-log-id}i" />
 
       </Host>
     </Engine>


### PR DESCRIPTION
- Logs the ActivityID for troubleshooting purposes
- Refer https://tomcat.apache.org/tomcat-8.5-doc/config/valve.html for detailed Tomcat reference
- This is a sample log message from site_access_log after making this change:
  `IPXXXXXXX - - [31/Jul/2019:21:12:49 +0000] "GET / HTTP/1.1" 200 1662 6  c0384a98-9169-4b8d-8eb2-c5ae187d2557`